### PR TITLE
Feature/safer ballot ets init

### DIFF
--- a/lib/caspax/application.ex
+++ b/lib/caspax/application.ex
@@ -2,7 +2,7 @@ defmodule Caspax.Application do
   use Application
 
   def start(_type, _args) do
-    Caspax.BallotNumber.new()
+    Caspax.BallotNumber.init()
     :pg2.create(Caspax.Acceptor.Preparers)
     :pg2.create(Caspax.Acceptor.Acceptors)
 

--- a/lib/caspax/ballot_number.ex
+++ b/lib/caspax/ballot_number.ex
@@ -1,5 +1,5 @@
 defmodule Caspax.BallotNumber do
-  def new do
+  def init do
     :ets.new(Caspax.BallotNumber, [
       :public,
       :set,

--- a/lib/caspax/ballot_number.ex
+++ b/lib/caspax/ballot_number.ex
@@ -1,29 +1,35 @@
 defmodule Caspax.BallotNumber do
   def init do
-    :ets.new(Caspax.BallotNumber, [
-      :public,
-      :set,
-      :named_table,
-      {:read_concurrency, true},
-      {:write_concurrency, true}
-    ])
+    try do
+      :ets.new(__MODULE__, [
+        :public,
+        :set,
+        :named_table,
+        {:read_concurrency, true},
+        {:write_concurrency, true}
+      ])
+    rescue
+      # the ets table already exists
+      # so we return the name of the table as :ets.new/2 does
+      ArgumentError -> __MODULE__
+    end
   end
 
   def get_next do
     :ets.update_counter(
-      Caspax.BallotNumber,
-      Caspax.BallotNumber,
+      __MODULE__,
+      __MODULE__,
       1,
-      {Caspax.BallotNumber, -1}
+      {__MODULE__, -1}
     )
   end
 
   def fast_forward(new_ballot_number) do
-    curr = :ets.lookup_element(Caspax.BallotNumber, Caspax.BallotNumber, 2)
+    curr = :ets.lookup_element(__MODULE__, __MODULE__, 2)
     diff = new_ballot_number - curr
 
     if diff > 0 do
-      :ets.update_counter(Caspax.BallotNumber, Caspax.BallotNumber, diff)
+      :ets.update_counter(__MODULE__, __MODULE__, diff)
     else
       curr
     end


### PR DESCRIPTION
Allow init() to be called more than once without throwing errors, and replace magic atoms with __MODULE__.