### PR TITLE
Feature/ffwd safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 caspax-*.tar
-
+*.swp

--- a/lib/caspax/application.ex
+++ b/lib/caspax/application.ex
@@ -2,7 +2,7 @@ defmodule Caspax.Application do
   use Application
 
   def start(_type, _args) do
-    Caspax.BallotNumber.new()
+    Caspax.BallotNumber.init()
     :pg2.create(Caspax.Acceptor.Preparers)
     :pg2.create(Caspax.Acceptor.Acceptors)
 

--- a/lib/caspax/ballot_number.ex
+++ b/lib/caspax/ballot_number.ex
@@ -25,13 +25,25 @@ defmodule Caspax.BallotNumber do
   end
 
   def fast_forward(new_ballot_number) do
-    curr = :ets.lookup_element(__MODULE__, __MODULE__, 2)
-    diff = new_ballot_number - curr
+    # the following is a match spec that looks for two-tuple entries
+    # (aka a counter) where the key is our key and the value is less
+    # than what we are fast forwarding to.
+    #
+    # not pretty, but ensures an atomic update to prevent race conditions
+    # between different processes trying to change the ballot number
+    #
+    # see http://erlang.org/doc/apps/erts/match_spec.html
+    ms = [
+      {
+        {:"$1", :"$2"},
+        [{:<, :"$2", {:const, new_ballot_number}}, {:"=:=", {:const, __MODULE__}, :"$1"}],
+        [{{:"$1", {:const, new_ballot_number}}}]
+      }
+    ]
 
-    if diff > 0 do
-      :ets.update_counter(__MODULE__, __MODULE__, diff)
-    else
-      curr
+    case :ets.select_replace(__MODULE__, ms) do
+      0 -> :ets.lookup_element(__MODULE__, __MODULE__, 2)
+      _ -> new_ballot_number
     end
   end
 end

--- a/lib/caspax/ballot_number.ex
+++ b/lib/caspax/ballot_number.ex
@@ -1,5 +1,5 @@
 defmodule Caspax.BallotNumber do
-  def new do
+  def init do
     :ets.new(Caspax.BallotNumber, [
       :public,
       :set,

--- a/lib/caspax/ballot_number.ex
+++ b/lib/caspax/ballot_number.ex
@@ -1,29 +1,35 @@
 defmodule Caspax.BallotNumber do
   def init do
-    :ets.new(Caspax.BallotNumber, [
-      :public,
-      :set,
-      :named_table,
-      {:read_concurrency, true},
-      {:write_concurrency, true}
-    ])
+    try do
+      :ets.new(__MODULE__, [
+        :public,
+        :set,
+        :named_table,
+        {:read_concurrency, true},
+        {:write_concurrency, true}
+      ])
+    rescue
+      # the ets table already exists
+      # so we return the name of the table as :ets.new/2 does
+      ArgumentError -> __MODULE__
+    end
   end
 
   def get_next do
     :ets.update_counter(
-      Caspax.BallotNumber,
-      Caspax.BallotNumber,
+      __MODULE__,
+      __MODULE__,
       1,
-      {Caspax.BallotNumber, -1}
+      {__MODULE__, -1}
     )
   end
 
   def fast_forward(new_ballot_number) do
-    curr = :ets.lookup_element(Caspax.BallotNumber, Caspax.BallotNumber, 2)
+    curr = :ets.lookup_element(__MODULE__, __MODULE__, 2)
     diff = new_ballot_number - curr
 
     if diff > 0 do
-      :ets.update_counter(Caspax.BallotNumber, Caspax.BallotNumber, diff)
+      :ets.update_counter(__MODULE__, __MODULE__, diff)
     else
       curr
     end

--- a/lib/caspax/ballot_number.ex
+++ b/lib/caspax/ballot_number.ex
@@ -8,11 +8,14 @@ defmodule Caspax.BallotNumber do
         {:read_concurrency, true},
         {:write_concurrency, true}
       ])
+      get_next()
     rescue
       # the ets table already exists
       # so we return the name of the table as :ets.new/2 does
       ArgumentError -> __MODULE__
     end
+
+    :ok
   end
 
   def get_next do
@@ -20,7 +23,7 @@ defmodule Caspax.BallotNumber do
       __MODULE__,
       __MODULE__,
       1,
-      {__MODULE__, -1}
+      {__MODULE__, -2}
     )
   end
 

--- a/lib/caspax/proposer.ex
+++ b/lib/caspax/proposer.ex
@@ -1,6 +1,10 @@
 defmodule Caspax.Proposer do
   use Caspax.Logger
 
+  def query(key, timeout \\ 1_000) do
+    propose(key, fn x -> x end, timeout)
+  end
+
   def propose(
         key,
         fun,

--- a/test/ballot_number_test.exs
+++ b/test/ballot_number_test.exs
@@ -1,0 +1,34 @@
+defmodule BallotNumberTest do
+  use ExUnit.Case
+  alias Caspax.BallotNumber
+  @moduletag BallotNumber
+
+  setup_all do
+    Caspax.BallotNumber = BallotNumber.init()
+    :ok
+  end
+
+  test "multi init works" do
+    assert Caspax.BallotNumber == BallotNumber.init()
+  end
+
+  test "reqular sequence works" do
+    assert 0 == BallotNumber.get_next()
+    assert 1 == BallotNumber.get_next()
+    assert 2 == BallotNumber.get_next()
+    assert 3 == BallotNumber.get_next()
+    assert 4 == BallotNumber.get_next()
+    assert 5 == BallotNumber.get_next()
+  end
+
+  test "fast forward works" do
+    assert 6 == BallotNumber.get_next()
+    assert 100 == BallotNumber.fast_forward(100)
+    assert 101 == BallotNumber.get_next()
+  end
+
+  test "fast forward does not go backwards" do
+    assert 101 == BallotNumber.fast_forward(0)
+    assert 102 == BallotNumber.get_next()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExUnit.configure seed: 0
 ExUnit.start()


### PR DESCRIPTION
Note: this builds on the previous pull requests, so looks bigger than it is as it includes those previous pull requests as well. It is really just the last two commits, with the important one being commit 2e9af3b

There is a race condition in fast_forward:

Suppose the ballot number is currently 100:

Process A                        Process B
Call fast_forward 103      Call fast_forward 105
gets current val: 100       gets current val: 100
calcs diff of 3                   calcs diff of 5
3 is > 0, so inc by 3       5 is > 0, so inc by 5

The result would be the ballot number now being 108 rather than 105. The problem is that nothing is locked before doing the read allowing incorrect diffs to be calculated.

This is more easily seen by introducing a Process.sleep/1 call directly after the :ets.lookup_element call in fast_forward, and then do something like:

pid = spawn(
fn ->
  receive do
    _ -> :ok
  end
  BallotNumber.fast_forward(130)
end)

pid2 = spawn(
fn ->
  receive do
    _ -> :ok
  end
  BallotNumber.fast_forward(140)
end)

send(pid, :ok); send(pid2, :ok);
:ets.lookup_element(Caspax.BallotNumber, Caspax.BallotNumber, 2)

If starting with the ballot number at 0, the ballot number after those calls will be 270 instead of 140.

This patch fixes that by using :ets.select_replace with a match spec. Ugly but effective :)

Also in this pull request: initialize the ballot number in init.